### PR TITLE
add dist meta to point ot repository

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -19,4 +19,15 @@ WriteMakefile(
     },
     AUTHOR =>
         'Brad Fitzpatrick (brad@danga.com), Brad Whitaker (whitaker@danga.com)',
+    META_MERGE => {
+        'meta-spec' => { version => 2 },
+        resources => {
+            repository => {
+                type => 'git',
+                url  => 'https://github.com/p-alik/Gearman-Server.git',
+                web  => 'https://github.com/p-alik/Gearman-Server',
+            },
+        },
+    },
+    
 );


### PR DESCRIPTION
Adding the github repository to the dist metadata will make metacpan link directly to the github repository and make it easier for developers to find the repository and make PRs directly to it.
